### PR TITLE
OSX Deploy Fixes and Working High Sierra Wallet

### DIFF
--- a/contrib/macdeploy/custom_dsstore.py
+++ b/contrib/macdeploy/custom_dsstore.py
@@ -54,7 +54,7 @@ ds['.']['icvp'] = icvp
 ds['.']['vSrn'] = ('long', 1)
 
 ds['Applications']['Iloc'] = (370, 156)
-ds['Zcoin-Qt.app']['Iloc'] = (128, 156)
+ds['Zoin-Qt.app']['Iloc'] = (128, 156)
 
 ds.flush()
 ds.close()

--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -6,7 +6,7 @@
 set -e
 
 ROOTDIR=dist
-BUNDLE="${ROOTDIR}/Zcoin-Qt.app"
+BUNDLE="${ROOTDIR}/Zoin-Qt.app"
 CODESIGN=codesign
 TEMPDIR=sign.temp
 TEMPLIST=${TEMPDIR}/signatures.txt

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -40,6 +40,18 @@ Build Zoin Core
 
         make deploy
 
+Build Zoin Core on High Sierra with Boost 1.66
+----------------------------------------------
+Follow the steps above. When configuring, you want to define the mt versions of the boost library.
+You will also need to define the compilers to use:
+
+    ./configure --with-boost-libdir=/usr/local/lib \
+                --with-boost-thread=boost_thread-mt \
+                --with-boost-chrono=boost_chrono-mt \
+                --with-boost-system=boost_system-mt \
+                --with-boost-filesystem=boost_filesystem-mt \
+                --with-boost-unit-test-framework=boost_unit_test_framework-mt \
+                CXX=$(which g++) CC=$(which gcc)
 
 Running
 -------

--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -29,10 +29,10 @@
   <string>????</string>
 
   <key>CFBundleExecutable</key>
-  <string>Zcoin-Qt</string>
+  <string>Zoin-Qt</string>
   
   <key>CFBundleName</key>
-  <string>Zcoin-Qt</string>
+  <string>Zoin-Qt</string>
 
   <key>LSHasLocalizedDisplayName</key>
   <true/>


### PR DESCRIPTION
This fixes the OSX wallet deploy by renaming a bunch of references. Also, I found that by compiling the wallet as indicated in the added documentation on High Sierra, I got the wallet working on High Sierra without the crash in protobuf and with the boost multithreaded libraries.

You can find the release here: https://github.com/beatrichartz/zoin/releases if you want to promote it into this repo.